### PR TITLE
use systemd to configure user environment

### DIFF
--- a/debian/nix.install
+++ b/debian/nix.install
@@ -1,0 +1,2 @@
+debian/nix.user.tmpfile usr/share/user-tmpfiles.d/nix-daemon.conf
+debin/nix.user.environment usr/lib/environment.d/nix-daemon.conf

--- a/debian/nix.user.environment
+++ b/debian/nix.user.environment
@@ -1,0 +1,3 @@
+NIX_REMOTE=daemon
+PATH="$HOME/.nix-profile/bin:/nix/var/nix/profiles/default/bin:$PATH"
+NIX_PATH="nixpkgs=/nix/var/nix/profiles/per-user/root/channels/nixpkgs:/nix/var/nix/profiles/per-user/root/channels"

--- a/debian/nix.user.tmpfile
+++ b/debian/nix.user.tmpfile
@@ -1,0 +1,6 @@
+#Type Path        Mode UID  GID  Age Argument
+d     %h/.nix-defexpr
+L     %h/.nix-defexpr/channels_root -    -    -    -  /nix/var/nix/profiles/per-user/root/channels
+d     /nix/var/nix/profiles/per-user/%u 0755
+L     %h/.nix-profile -    -    -    -  /nix/var/nix/profiles/per-user/%u/profile
+d     /nix/var/nix/gcroots/per-user/%u 0755


### PR DESCRIPTION
Sitting in a train with bad internet but wanted to show how we could set up the user env with systemd.
I'd prefer us not to install the script to /etc/profile.d but only provide the script as example, see dh_installexamples.
Systemd config files can be easily overwritten and provide an easy overview of what needs to be done in case the user does not use systemd. The bash script only works for bash and can not be overridden without root privileges.